### PR TITLE
arreglando problemas color texto tablas

### DIFF
--- a/dist/habanero.css
+++ b/dist/habanero.css
@@ -1268,7 +1268,7 @@ table {
 
 .table.style1 td {
   font-size: 15px;
-  color: var(--table-body-color);
+  /*color: var(--table-body-color);*/
   line-height: 1.4;
 }
 
@@ -1299,7 +1299,7 @@ table {
 
 .table.style2 td {
   font-size: 15px;
-  color: var(--table-body-color);
+  /*color: var(--table-body-color);*/
   line-height: 1.4;
 }
 
@@ -1332,7 +1332,8 @@ table {
 
 .table.style3 td {
   font-size: 15px;
-  color: var(--table-body-color);
+  /*color: var(--table-body-color);*/
+  color: white;
   line-height: 1.4;
   background-color: var(--table-style3-body-bgcolor);
 }
@@ -1367,7 +1368,7 @@ table {
 
 .table.style4 td {
   font-size: 15px;
-  color: var(--table-body-color);
+  /*color: var(--table-body-color);*/
   line-height: 1.4;
 }
 
@@ -1403,7 +1404,7 @@ table {
 
 .table.style5 td {
   font-size: 15px;
-  color: var(--table-body-color);
+  /*color: var(--table-body-color);*/
   line-height: 1.4;
   background-color: var(--table-style5-body-bgcolor);
 }

--- a/examples/tables/css/styles.css
+++ b/examples/tables/css/styles.css
@@ -26,6 +26,7 @@
     /*End table variables*/
 }
 
+
 /*Start table classes*/
 /*Scroll bar*/
 .scroll {
@@ -132,7 +133,7 @@
   
   .table.style1 td {
     font-size: 15px;
-    color: var(--table-body-color);
+    /*color: var(--table-body-color);*/
     line-height: 1.4;
   }
   
@@ -163,7 +164,7 @@
   
   .table.style2 td {
     font-size: 15px;
-    color: var(--table-body-color);
+    /*color: var(--table-body-color);*/
     line-height: 1.4;
   }
   
@@ -196,7 +197,8 @@
   
   .table.style3 td {
     font-size: 15px;
-    color: var(--table-body-color);
+    /*color: var(--table-body-color);*/
+    color: white;
     line-height: 1.4;
     background-color: var(--table-style3-body-bgcolor);
   }
@@ -231,7 +233,7 @@
   
   .table.style4 td {
     font-size: 15px;
-    color: var(--table-body-color);
+    /*color: var(--table-body-color);*/
     line-height: 1.4;
   }
   
@@ -267,7 +269,7 @@
   
   .table.style5 td {
     font-size: 15px;
-    color: var(--table-body-color);
+    /*color: var(--table-body-color);*/
     line-height: 1.4;
     background-color: var(--table-style5-body-bgcolor);
   }


### PR DESCRIPTION
arreglando problemas color texto tablas. Cuando se queria darle color de texto distinto del predeterminado no dejaba en las casillas de las tablas, asi que se removio el color predeterminado excepto para la tabla de estilo 3